### PR TITLE
state-handler: add proper way of non-blinking lcd

### DIFF
--- a/StateHandler/inc/StateHandler.h
+++ b/StateHandler/inc/StateHandler.h
@@ -103,7 +103,8 @@ private:
   void SetState (state_pointer newstate);
   bool current_mode;
   Counter value[2] = { { 0, 100 }, { 0, 120 } };
-  int saved_set_value, saved_curr_value;
+  int saved_set_value[2] = { 0, 0 };
+  int saved_curr_value[2] = { 0, 0 };
   LiquidCrystal *_lcd;
 
   /** Initialization state
@@ -136,6 +137,14 @@ private:
    * @param button current button
    */
   void handleControlButtons (uint8_t button);
+
+  /** Save values to class' varibales
+   *
+   * @param eventValue value coming from an event
+   * @param counterValue value of the inner Counter
+   * @param mode current mode
+   */
+  void save (int eventValue, int counterValue, size_t mode);
 };
 
 #endif /* STATE_HANDLER_H_ */

--- a/StateHandler/src/StateHandler.cpp
+++ b/StateHandler/src/StateHandler.cpp
@@ -13,8 +13,6 @@ StateHandler::StateHandler (LiquidCrystal *lcd)
   current = &StateHandler::stateInit;
   (this->*current) (Event (Event::eEnter));
   current_mode = MANUAL;
-  saved_set_value = 0;
-  saved_curr_value = 0;
 }
 
 StateHandler::~StateHandler ()
@@ -112,13 +110,7 @@ StateHandler::stateManual (const Event &event)
       handleControlButtons (event.value);
       break;
     case Event::eTick:
-      if (saved_curr_value != event.value
-          || saved_set_value != value[MANUAL].getCurrent ())
-        {
-          saved_curr_value = event.value;
-          saved_set_value = value[MANUAL].getCurrent ();
-          displaySet (value[MANUAL].getCurrent (), event.value);
-        }
+      save (event.value, value[MANUAL].getCurrent (), MANUAL);
       break;
     }
 }
@@ -137,13 +129,7 @@ StateHandler::stateAuto (const Event &event)
       handleControlButtons (event.value);
       break;
     case Event::eTick:
-      if (saved_curr_value != event.value
-          || saved_set_value != value[AUTO].getCurrent ())
-        {
-          saved_curr_value = event.value;
-          saved_set_value = value[AUTO].getCurrent ();
-          displaySet (value[AUTO].getCurrent (), event.value);
-        }
+      save (event.value, value[AUTO].getCurrent (), AUTO);
       break;
     }
 }
@@ -165,5 +151,17 @@ StateHandler::handleControlButtons (uint8_t button)
       break;
     default:
       break;
+    }
+}
+
+void
+StateHandler::save (int eventValue, int counterValue, size_t mode)
+{
+  if (saved_curr_value[mode] != eventValue
+      || saved_set_value[mode] != counterValue)
+    {
+      saved_curr_value[mode] = eventValue;
+      saved_set_value[mode] = counterValue;
+      displaySet (counterValue, eventValue);
     }
 }


### PR DESCRIPTION
This commit adds a save() method for comparison of values communicating via main and stateHandler to avoid printing every milliseconds