### PR TITLE
Timer: add millis() for modbus

### DIFF
--- a/Timer/inc/Timer.h
+++ b/Timer/inc/Timer.h
@@ -13,6 +13,7 @@
 #include <climits>
 
 static volatile std::atomic_int timer;
+static volatile unsigned int systicks = 0;
 
 extern "C"
 {
@@ -22,6 +23,9 @@ extern "C"
    */
   void SysTick_Handler (void);
 }
+
+uint32_t millis();
+
 
 class Timer
 {

--- a/Timer/src/Timer.cpp
+++ b/Timer/src/Timer.cpp
@@ -12,6 +12,7 @@ extern "C"
   void
   SysTick_Handler (void)
   {
+	systicks++;
     if (timer > 0)
       timer--;
   }
@@ -62,4 +63,8 @@ void
 Timer::resetCounter ()
 {
   counter.store (0, std::memory_order_relaxed);
+}
+
+uint32_t millis() {
+	return systicks;
 }


### PR DESCRIPTION
We need millis() functioning for ModbusMaster class. Since we are using SysTick in Timer only the problem can be solved by defining millis() in Timer.